### PR TITLE
NASAFF-226

### DIFF
--- a/Classes/Domain/Model/Forum.php
+++ b/Classes/Domain/Model/Forum.php
@@ -100,7 +100,7 @@ class Forum extends AbstractEntity
      *
      * @return Forum
      */
-    public function setArchived(bool $archived): Forum
+    public function setArchived(bool $archived): self
     {
         $this->archived = $archived;
         return $this;

--- a/Classes/ViewHelper/NumerusWordViewHelper.php
+++ b/Classes/ViewHelper/NumerusWordViewHelper.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * This file is part of the package jweiland/pforum.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace JWeiland\Pforum\ViewHelper;
+
+use TYPO3\CMS\Extbase\Utility\LocalizationUtility;
+use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
+
+/**
+ * Extends the existing fluid script view helper to set dependencies between scripts.
+ *
+ * @author  Axel Seemann <axel.seemann@netresearch.de>
+ * @license Netresearch https://www.netresearch.de
+ * @link    https://www.netresearch.de
+ */
+class NumerusWordViewHelper extends AbstractViewHelper
+{
+    public function initializeArguments(): void
+    {
+        $this->registerArgument('number', 'int', 'The content to count the words for', true);
+        $this->registerArgument('singular', 'string', 'The singular form of the word', true);
+        $this->registerArgument('plural', 'string', 'The plural form of the word', true);
+    }
+
+    public function render(): string
+    {
+        $number   = $this->arguments['number'];
+        $singular = $this->arguments['singular'];
+        $plural   = $this->arguments['plural'];
+
+        if ($number === 0) {
+            return LocalizationUtility::translate('LLL:EXT:pforum/Resources/Private/Language/locallang.xlf:numword.no') . ' ' . $plural;
+        }
+
+        if ($number === 1) {
+            return $number . ' ' . $singular;
+        }
+        return $number . ' ' . $plural;
+    }
+}

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -224,6 +224,27 @@
 			<trans-unit id="be.noRecordsInStorage">
 				<source>Currently, there are no hidden records for selected record type.</source>
 			</trans-unit>
+			<trans-unit id="numword.no">
+				<source>no</source>
+			</trans-unit>
+			<trans-unit id="numword.topic">
+				<source>topic</source>
+			</trans-unit>
+			<trans-unit id="numword.topics">
+				<source>topics</source>
+			</trans-unit>
+			<trans-unit id="numword.post">
+				<source>topic</source>
+			</trans-unit>
+			<trans-unit id="numword.post">
+				<source>topics</source>
+			</trans-unit>
+			<trans-unit id="numword.comment">
+				<source>comments</source>
+			</trans-unit>
+			<trans-unit id="numword.comments">
+				<source>comments</source>
+			</trans-unit>
 		</body>
 	</file>
 </xliff>

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -234,10 +234,10 @@
 				<source>topics</source>
 			</trans-unit>
 			<trans-unit id="numword.post">
-				<source>topic</source>
+				<source>post</source>
 			</trans-unit>
-			<trans-unit id="numword.post">
-				<source>topics</source>
+			<trans-unit id="numword.posts">
+				<source>posts</source>
 			</trans-unit>
 			<trans-unit id="numword.comment">
 				<source>comments</source>

--- a/Resources/Private/Partials/Component/Topic/Detail.html
+++ b/Resources/Private/Partials/Component/Topic/Detail.html
@@ -1,6 +1,7 @@
 <html data-namespace-typo3-fluid="true"
       xmlns="http://www.w3.org/1999/xhtml" lang="en"
       xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
+      xmlns:pf="http://typo3.org/ns/JWeiland/Pforum/ViewHelper"
 >
     <div class="card mb-3 bg-light">
         <div class="row g-0">
@@ -32,7 +33,7 @@
                             {topic.crdate -> f:format.date(format: 'd.m.Y')}&nbsp;|
                             {f:translate(key: 'from')}:
                             <f:render partial="User/Username" arguments="{user: topic.user}" /> |
-                            {topic.posts -> f:count()}&nbsp;{f:translate(key: 'tx_pforum_domain_model_topic.posts')}
+                            <pf:numerusWord number="{topic.posts -> f:count()}" singular="{f:translate(key: 'numword.post')}" plural="{f:translate(key: 'numword.posts')}" />
                         </small>
                     </div>
 

--- a/Resources/Private/Templates/Forum/Show.html
+++ b/Resources/Private/Templates/Forum/Show.html
@@ -33,7 +33,7 @@
 								{topic.crdate -> f:format.date(format: 'd.m.Y')}&nbsp;|
 								{f:translate(key: 'from')}:
 								<f:render partial="User/Username" arguments="{user: topic.user}" /> |
-								{topic.posts -> f:count()}&nbsp;{f:translate(key: 'tx_pforum_domain_model_topic.posts')}
+								<pf:numerusWord number="{topic.posts -> f:count()}" singular="{f:translate(key: 'numword.post')}" plural="{f:translate(key: 'numword.posts')}" />
 							</small>
 						</div>
 

--- a/Resources/Private/Templates/Topic/Edit.html
+++ b/Resources/Private/Templates/Topic/Edit.html
@@ -1,5 +1,6 @@
 <html lang="en"
 			xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
+	  		xmlns:pf="http://typo3.org/ns/JWeiland/Pforum/ViewHelper"
 			data-namespace-typo3-fluid="true">
 
 <f:layout name="Default" />
@@ -39,7 +40,7 @@
 							{topic.crdate -> f:format.date(format: 'd.m.Y')}&nbsp;|
 							{f:translate(key: 'from')}:
 							<f:render partial="User/Username" arguments="{user: topic.user}" /> |
-							{topic.posts -> f:count()}&nbsp;{f:translate(key: 'tx_pforum_domain_model_topic.posts')}
+							<pf:numerusWord number="{topic.posts -> f:count()}" singular="{f:translate(key: 'numword.post')}" plural="{f:translate(key: 'numword.posts')}" />
 						</small>
 					</div>
 


### PR DESCRIPTION
Add NumerusWord Viewhelper to display labels in singular and plural depending on the count of, for example, topics. 

Usage: 
```
<html
     xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
      xmlns:pf="http://typo3.org/ns/JWeiland/Pforum/ViewHelpers"
      data-namespace-typo3-fluid="true"
>
    <pf:numerusWord number="{topic.posts -> f:count()}" singular="{f:translate(key: 'numnword.topic')}" plural="{f:translate(key: 'numnword.topics')}" />
</html>
```

See: NASAFF-226 for details. 